### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari team

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@conda-forge/napari](https://github.com/conda-forge/napari/)
+* [@goanpeca](https://github.com/goanpeca/)
+* [@jaimergp](https://github.com/jaimergp/)
 * [@jburel](https://github.com/jburel/)
 * [@joshmoore](https://github.com/joshmoore/)
 * [@sbesson](https://github.com/sbesson/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,8 @@ about:
 extra:
   recipe-maintainers:
     - jburel
-    - conda-forge/napari
+    - goanpeca
+    - jaimergp
     - joshmoore
     - sbesson
     - will-moore


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.