### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@jburel](https://github.com/jburel/)
 * [@jo-mueller](https://github.com/jo-mueller/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ about:
 extra:
   recipe-maintainers:
     - jburel
-    - goanpeca
     - jaimergp
     - joshmoore
     - will-moore


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #16